### PR TITLE
change int(math.floor()) to int()

### DIFF
--- a/pyope/stat.py
+++ b/pyope/stat.py
@@ -34,7 +34,7 @@ def sample_uniform(in_range, seed_coins):
     cur_range = in_range.copy()
     assert cur_range.size() != 0
     while cur_range.size() > 1:
-        mid = int(math.floor((cur_range.start + cur_range.end) / 2))
+        mid = int((cur_range.start + cur_range.end) / 2)
         bit = next(seed_coins)
         if bit == 0:
             cur_range.end = mid


### PR DESCRIPTION
`cipher = OPE(b'key11', in_range=ValueRange(0,0), out_range=ValueRange(0, 2**65))`
`pt=0`
Error info:
assert cur_range.size() != 0

int(math.floor()) returns wrong value on the input 
a = 392042517006302273
b = 392042517006302336
should return middle = 392042517006302304
but it returns 392042517006302336